### PR TITLE
Remove dependency on backend model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,26 +31,7 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
     <dependencies>
-        <dependency>
-            <groupId>com.github.ONSdigital</groupId>
-            <artifactId>dp-dd-backend-model</artifactId>
-            <version>develop-SNAPSHOT</version>
-        </dependency>
-        <!--
-                <dependency>
-                    <groupId>uk.co.onsdigital.discovery</groupId>
-                    <artifactId>dd-model</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                </dependency>
-        -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/uk/co/onsdigital/job/Application.java
+++ b/src/main/java/uk/co/onsdigital/job/Application.java
@@ -19,7 +19,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
 import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
 import org.springframework.transaction.jta.JtaTransactionManager;
-import uk.co.onsdigital.discovery.model.DimensionalDataSet;
 import uk.co.onsdigital.job.model.Job;
 import uk.co.onsdigital.job.repository.DataSetRepository;
 
@@ -32,7 +31,7 @@ import java.util.Properties;
  * Spring boot application configuration.
  */
 @SpringBootApplication
-@EntityScan(basePackageClasses = { DimensionalDataSet.class, Job.class })
+@EntityScan(basePackageClasses = { Job.class })
 @EnableJpaRepositories(basePackageClasses = DataSetRepository.class)
 public class Application extends JpaBaseConfiguration {
     private static final Logger log = LoggerFactory.getLogger(Application.class);

--- a/src/main/java/uk/co/onsdigital/job/exception/NoSuchDataSetException.java
+++ b/src/main/java/uk/co/onsdigital/job/exception/NoSuchDataSetException.java
@@ -1,0 +1,16 @@
+package uk.co.onsdigital.job.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.UUID;
+
+/**
+ * Indicates that the requested dataset does not exist in the database.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class NoSuchDataSetException extends RuntimeException {
+    public NoSuchDataSetException(UUID datasetId) {
+        super("Dataset not found: " + datasetId);
+    }
+}

--- a/src/main/java/uk/co/onsdigital/job/repository/DataSetRepository.java
+++ b/src/main/java/uk/co/onsdigital/job/repository/DataSetRepository.java
@@ -1,8 +1,10 @@
 package uk.co.onsdigital.job.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-import uk.co.onsdigital.discovery.model.DimensionalDataSet;
+import uk.co.onsdigital.job.exception.NoSuchDataSetException;
 
 import java.util.UUID;
 
@@ -10,5 +12,25 @@ import java.util.UUID;
  * Repository for looking up datasets.
  */
 @Repository
-public interface DataSetRepository extends JpaRepository<DimensionalDataSet, UUID> {
+public class DataSetRepository {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * Looks up the S3 URL for the given dataset.
+     *
+     * @param dataSetId the id of the dataset to lookup.
+     * @return the S3 URL of that dataset.
+     * @throws NoSuchDataSetException if the dataset does not exist.
+     */
+    public String findS3urlForDataSet(UUID dataSetId) {
+        try {
+            return jdbcTemplate.queryForObject("SELECT ds.s3_url FROM dimensional_data_set ds WHERE ds.dimensional_data_set_id = ?",
+                    String.class, dataSetId);
+        } catch (EmptyResultDataAccessException e) {
+            throw new NoSuchDataSetException(dataSetId);
+        }
+    }
+
 }

--- a/src/main/java/uk/co/onsdigital/job/service/FilterServiceClient.java
+++ b/src/main/java/uk/co/onsdigital/job/service/FilterServiceClient.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.co.onsdigital.discovery.model.DimensionalDataSet;
 import uk.co.onsdigital.job.exception.ServiceUnavailableException;
 import uk.co.onsdigital.job.model.FileFormat;
 import uk.co.onsdigital.job.model.FileStatus;
@@ -47,11 +46,11 @@ public class FilterServiceClient {
     /**
      * Submits a request to the CSV filter component to produce the given output formats.
      *
-     * @param dataSet       the dataset to filter.
+     * @param dataSetS3Url  the S3 URL of the dataset to filter.
      * @param files         the files to create.
      * @param filters       the set of dimension filters to apply.
      */
-    public void submitFilterRequest(final DimensionalDataSet dataSet, final Map<FileFormat, FileStatus> files,
+    public void submitFilterRequest(final String dataSetS3Url, final Map<FileFormat, FileStatus> files,
                                     final Map<String, ? extends Set<String>> filters) {
 
         if (files == null || files.isEmpty()) {
@@ -65,7 +64,7 @@ public class FilterServiceClient {
             }
 
             final FilterRequest filterRequest = FilterRequest.builder()
-                    .inputUrl(dataSet.getS3URL())
+                    .inputUrl(dataSetS3Url)
                     .outputUrl("s3://" + outputS3Bucket + "/" + file.getName())
                     .dimensions(filters)
                     .build();


### PR DESCRIPTION
### What

Removes the dependency on the backend JPA model. The job creator was only using it to lookup the S3 URL of the dataset to pass through to the filter. I've removed all that and replaced with the one line JDBC query to do the same thing.

### How to review

`mvn clean spring-boot:run` and check that you can still create and read jobs correctly.

### Who can review

Anyone but me.