### PR TITLE
Move job tables into a separate schema.

### DIFF
--- a/src/main/java/uk/co/onsdigital/job/model/FileStatus.java
+++ b/src/main/java/uk/co/onsdigital/job/model/FileStatus.java
@@ -15,7 +15,7 @@ import javax.persistence.Table;
 /**
  * Indicates the status of a particular output file in a job.
  */
-@Data @Entity @Table(name = "file_status")
+@Data @Entity @Table(name = "file_status", schema = "job_creator")
 public class FileStatus {
     @Id
     private @NonNull String name;

--- a/src/main/java/uk/co/onsdigital/job/model/Job.java
+++ b/src/main/java/uk/co/onsdigital/job/model/Job.java
@@ -7,17 +7,7 @@ import lombok.NonNull;
 import lombok.Singular;
 import lombok.experimental.Tolerate;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import javax.persistence.*;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -25,7 +15,7 @@ import java.util.List;
 /**
  * Represents a file generation job that has been submitted.
  */
-@Entity @Table(name = "file_gen_job")
+@Entity @Table(name = "job", schema = "job_creator")
 @Data @Builder
 public class Job {
     @Id
@@ -36,6 +26,7 @@ public class Job {
     private @NonNull Status status = Status.PENDING;
 
     @OneToMany(cascade = {CascadeType.ALL}, fetch = FetchType.EAGER)
+    @JoinTable(name = "job_file_status", schema = "job_creator")
     private @NonNull @Singular  List<FileStatus> files = Collections.emptyList();
 
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,10 @@ spring.jpa.show-sql=true
 spring.jpa.properties.eclipselink.weaving=false
 spring.jpa.properties.eclipselink.ddl-generation=create-or-extend-tables
 
+spring.jpa.properties.javax.persistence.schema-generation.database.action=create
+spring.jpa.properties.javax.persistence.schema-generation.create-source=script
+spring.jpa.properties.javax.persistence.schema-generation.create-script-source=schema.sql
+
 output.s3.bucket=dp-dd-csv-filter
 download.url.template=https://www.ons.gov.uk/download/{filename}
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS job_creator;


### PR DESCRIPTION
### What

As a quick fix to avoid clashes with Flyway, this moves the job creator status tables into a separate schema so that Flyway does not trample over them. In the long term this should probably move to a separate database entirely, but currently the job creator also needs to access the dataset table (to get the S3 URL).

### How to review

`mvn clean spring-boot:run` then fire some requests at it as per the README.md

### Who can review

Anyone but me.