### PR TITLE
Avoid submitting the same file more than once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-dd-backend-model</artifactId>
-            <version>feature~file_status_expiry-SNAPSHOT</version>
+            <version>develop-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.ONSdigital</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
             <artifactId>dp-dd-backend-model</artifactId>
-            <version>v1.0.2</version>
+            <version>feature~file_status_expiry-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.ONSdigital</groupId>

--- a/src/main/java/uk/co/onsdigital/job/JobController.java
+++ b/src/main/java/uk/co/onsdigital/job/JobController.java
@@ -83,7 +83,7 @@ public class JobController {
         dataSetS3Url = dataSetRepository.findS3urlForDataSet(request.getDataSetId());
         final Map<FileFormat, FileStatusDto> files = getInitialFileStatus(request);
 
-        final JobDto jobDto = new JobDto(files.values(), new Date(now().plus(1, HOURS).toEpochMilli()));
+        final JobDto jobDto = new JobDto(files.values(), Date.from(now().plus(1, HOURS)));
 
         // Check to see if the files already exist
         jobStatusChecker.updateStatus(jobDto);

--- a/src/main/java/uk/co/onsdigital/job/JobController.java
+++ b/src/main/java/uk/co/onsdigital/job/JobController.java
@@ -9,9 +9,22 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
-import uk.co.onsdigital.job.exception.*;
-import uk.co.onsdigital.job.model.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import uk.co.onsdigital.job.exception.NoSuchDataSetException;
+import uk.co.onsdigital.job.exception.NoSuchJobException;
+import uk.co.onsdigital.job.exception.TooManyRequestsException;
+import uk.co.onsdigital.job.model.CreateJobRequest;
+import uk.co.onsdigital.job.model.FileFormat;
+import uk.co.onsdigital.job.model.FileStatusDto;
+import uk.co.onsdigital.job.model.JobDto;
 import uk.co.onsdigital.job.persistence.DataSetRepository;
 import uk.co.onsdigital.job.persistence.JobRepository;
 import uk.co.onsdigital.job.service.FilterServiceClient;
@@ -22,11 +35,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Base64;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
 
 import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.HOURS;
 import static uk.co.onsdigital.job.model.StatusDto.PENDING;
 
 /**
@@ -65,26 +81,21 @@ public class JobController {
         log.debug("Processing jobDto request: {}", request);
         final String dataSetS3Url;
         dataSetS3Url = dataSetRepository.findS3urlForDataSet(request.getDataSetId());
-        final Map<FileFormat, FileStatusDto> files = generateFileNames(request);
+        final Map<FileFormat, FileStatusDto> files = getInitialFileStatus(request);
 
-        final JobDto jobDto = new JobDto();
-        jobDto.setId(UUID.randomUUID().toString());
-        jobDto.setStatus(PENDING);
-        jobDto.setFiles(files.values().stream().collect(Collectors.toList()));
-        jobDto.setExpiryTime(new Date(now().plus(1, ChronoUnit.HOURS).toEpochMilli()));
+        final JobDto jobDto = new JobDto(files.values(), new Date(now().plus(1, HOURS).toEpochMilli()));
+
         // Check to see if the files already exist
         jobStatusChecker.updateStatus(jobDto);
 
         if (jobDto.isComplete()) {
-            jobRepository.save(jobDto);
-            return jobDto;
+            return jobRepository.save(jobDto);
         }
         if (jobRepository.countJobsWithStatus(PENDING) >= pendingJobLimit) {
             throw new TooManyRequestsException("Sorry - the number of requested jobs exceeds the limit");
         }
         filterServiceClient.submitFilterRequest(dataSetS3Url, files, request.getSortedDimensionFilters());
-        jobRepository.save(jobDto);
-        return jobDto;
+        return jobRepository.save(jobDto);
     }
 
     @ExceptionHandler(NoSuchDataSetException.class)
@@ -131,12 +142,26 @@ public class JobController {
          log.debug("Exception: {}", e);
     }
 
+    /**
+     * Determines the initial status of any files that need to be generated. The file name will be based on a SHA-256
+     * hash of the dataset ID and the (sorted) dimension filters so that all requests for the same filtering of the same
+     * dataset will result in the same filename being requested. We check in the database for any existing known status
+     * of the files that have been requested to avoid requesting them twice.
+     *
+     * @param request the request to generate file status for.
+     * @return a map from requested file formats to the initial status of the file to be generated.
+     */
     @VisibleForTesting
-    static Map<FileFormat, FileStatusDto> generateFileNames(final CreateJobRequest request) {
+    Map<FileFormat, FileStatusDto> getInitialFileStatus(final CreateJobRequest request) {
         final String baseFileName = generateBaseFileName(request);
         final Map<FileFormat, FileStatusDto> result = new EnumMap<>(FileFormat.class);
         for (FileFormat format : request.getFileFormats()) {
-            result.put(format, new FileStatusDto(baseFileName + format.getExtension()));
+            String fileName = baseFileName + format.getExtension();
+            FileStatusDto fileStatusDto = jobRepository.findFileStatus(fileName);
+            if (fileStatusDto == null) {
+                fileStatusDto = new FileStatusDto(fileName);
+            }
+            result.put(format, fileStatusDto);
         }
         return result;
     }

--- a/src/main/java/uk/co/onsdigital/job/model/FileStatusDto.java
+++ b/src/main/java/uk/co/onsdigital/job/model/FileStatusDto.java
@@ -2,11 +2,10 @@ package uk.co.onsdigital.job.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Data;
 import lombok.NonNull;
-import lombok.experimental.Tolerate;
-import uk.co.onsdigital.discovery.model.FileStatus;
-import uk.co.onsdigital.discovery.model.Status;
+import uk.co.onsdigital.discovery.model.*;
+
+import java.util.Date;
 
 
 /**
@@ -21,10 +20,7 @@ public class FileStatusDto {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private String url;
 
-    @Tolerate
-    FileStatusDto() {
-        // Default constructor for JPA
-    }
+    private Date submittedAt;
 
     public FileStatusDto(String name) {
         this.name = name;
@@ -33,6 +29,21 @@ public class FileStatusDto {
     @JsonIgnore
     public boolean isComplete() {
         return status == StatusDto.COMPLETE;
+    }
+
+    /** Whether the job has been submitted to the filterer or not. */
+    @JsonIgnore
+    public boolean isSubmitted() {
+        return submittedAt != null;
+    }
+
+    @JsonIgnore
+    public Date getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(Date submittedAt) {
+        this.submittedAt = submittedAt;
     }
 
     public String getName() {
@@ -64,17 +75,21 @@ public class FileStatusDto {
         fileStatus.setStatus(StatusDto.convertToModel(this.status));
         fileStatus.setName(this.name);
         fileStatus.setUrl(this.url);
+        fileStatus.setSubmittedAt(this.submittedAt);
         return fileStatus;
     }
 
     public static FileStatusDto convertFromModel(FileStatus fileStatus) {
-        FileStatusDto fileStatusDto = new FileStatusDto();
-
-        fileStatusDto.setName(fileStatus.getName());
+        FileStatusDto fileStatusDto = new FileStatusDto(fileStatus.getName());
         fileStatusDto.setStatus(StatusDto.fromString(fileStatus.getStatus().toString()));
         fileStatusDto.setUrl(fileStatus.getUrl());
+        fileStatusDto.setSubmittedAt(fileStatus.getSubmittedAt());
 
         return fileStatusDto;
     }
 
+    @Override
+    public String toString() {
+        return "FileStatusDto{name='" + name  + "', status=" + status + ", url='" + url + "', submittedAt=" + submittedAt + "}";
+    }
 }

--- a/src/main/java/uk/co/onsdigital/job/model/JobDto.java
+++ b/src/main/java/uk/co/onsdigital/job/model/JobDto.java
@@ -1,14 +1,14 @@
 package uk.co.onsdigital.job.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import uk.co.onsdigital.discovery.model.FileStatus;
-import uk.co.onsdigital.discovery.model.Job;
-import uk.co.onsdigital.discovery.model.Status;
+import uk.co.onsdigital.discovery.model.*;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -27,6 +27,10 @@ public class JobDto {
 
     public JobDto () {
 
+    }
+
+    public JobDto(Collection<FileStatusDto> files, Date expiryTime) {
+        this(UUID.randomUUID().toString(), StatusDto.PENDING, new ArrayList<>(files), expiryTime);
     }
 
     private JobDto(String id, StatusDto status, List<FileStatusDto> files, Date expiryTime) {
@@ -91,5 +95,10 @@ public class JobDto {
         jobDto.setId(job.getId());
         jobDto.setFiles(job.getFiles().stream().map(FileStatusDto::convertFromModel).collect(Collectors.toList()));
         return jobDto;
+    }
+
+    @Override
+    public String toString() {
+        return "JobDto{id='" + id + "', status=" + status + ", files=" + files + ", expiryTime=" + expiryTime + '}';
     }
 }

--- a/src/main/java/uk/co/onsdigital/job/persistence/JobRepository.java
+++ b/src/main/java/uk/co/onsdigital/job/persistence/JobRepository.java
@@ -33,13 +33,6 @@ public class JobRepository {
         entityManager.createNamedQuery(Job.DELETE_JOBS_EXPIRING_BEFORE).setParameter(Job.BEFORE_DATE_PARAM, before).executeUpdate();
     }
 
-    @Transactional
-    public void deleteFilesGeneratedBefore(Date before) {
-        entityManager.createNamedQuery(FileStatus.DELETE_EXPIRED_FILES)
-                .setParameter(FileStatus.BEFORE_PARAM, before)
-                .executeUpdate();
-    }
-
     public JobDto save(JobDto jobDto) {
         return JobDto.convertFromModel(entityManager.merge(jobDto.convertToModel()));
     }

--- a/src/main/java/uk/co/onsdigital/job/persistence/JobRepository.java
+++ b/src/main/java/uk/co/onsdigital/job/persistence/JobRepository.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.co.onsdigital.discovery.model.*;
+import uk.co.onsdigital.job.model.FileStatusDto;
 import uk.co.onsdigital.job.model.JobDto;
 import uk.co.onsdigital.job.model.StatusDto;
 
@@ -32,8 +33,15 @@ public class JobRepository {
         entityManager.createNamedQuery(Job.DELETE_JOBS_EXPIRING_BEFORE).setParameter(Job.BEFORE_DATE_PARAM, before).executeUpdate();
     }
 
-    public void save(JobDto jobDto) {
-        entityManager.merge(jobDto.convertToModel());
+    @Transactional
+    public void deleteFilesGeneratedBefore(Date before) {
+        entityManager.createNamedQuery(FileStatus.DELETE_EXPIRED_FILES)
+                .setParameter(FileStatus.BEFORE_PARAM, before)
+                .executeUpdate();
+    }
+
+    public JobDto save(JobDto jobDto) {
+        return JobDto.convertFromModel(entityManager.merge(jobDto.convertToModel()));
     }
 
     public JobDto findOne(String jobId) throws NoResultException {
@@ -43,5 +51,13 @@ public class JobRepository {
 
     public void delete(String jobId) {
         entityManager.createNamedQuery(Job.DELETE_ONE_QUERY).setParameter(Job.ID_PARAM, jobId);
+    }
+
+    public FileStatusDto findFileStatus(String filename) {
+        FileStatus status = entityManager.find(FileStatus.class, filename);
+        if (status != null) {
+            return FileStatusDto.convertFromModel(status);
+        }
+        return null;
     }
 }

--- a/src/main/java/uk/co/onsdigital/job/persistence/JobRepository.java
+++ b/src/main/java/uk/co/onsdigital/job/persistence/JobRepository.java
@@ -37,8 +37,11 @@ public class JobRepository {
         return JobDto.convertFromModel(entityManager.merge(jobDto.convertToModel()));
     }
 
-    public JobDto findOne(String jobId) throws NoResultException {
+    public JobDto findOne(String jobId) {
         Job job = entityManager.find(Job.class, jobId);
+        if (job == null) {
+            return null;
+        }
         return JobDto.convertFromModel(job);
     }
 

--- a/src/main/java/uk/co/onsdigital/job/service/Scheduler.java
+++ b/src/main/java/uk/co/onsdigital/job/service/Scheduler.java
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.co.onsdigital.job.persistence.JobRepository;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 /**
@@ -30,6 +31,9 @@ public class Scheduler {
     @Scheduled(initialDelay = 1000, fixedRate = 60000)
     void deleteExpiredJobs() {
         log.debug("Deleting expired jobs");
-        jobRepository.deleteJobsExpiringBefore(new Date());
+        final Date now = new Date();
+        jobRepository.deleteJobsExpiringBefore(now);
+        log.debug("Deleting old generated files from database");
+        jobRepository.deleteFilesGeneratedBefore(Date.from(now.toInstant().minus(2, ChronoUnit.HOURS)));
     }
 }

--- a/src/main/java/uk/co/onsdigital/job/service/Scheduler.java
+++ b/src/main/java/uk/co/onsdigital/job/service/Scheduler.java
@@ -7,7 +7,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.co.onsdigital.job.persistence.JobRepository;
 
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 /**
@@ -31,9 +30,6 @@ public class Scheduler {
     @Scheduled(initialDelay = 1000, fixedRate = 60000)
     void deleteExpiredJobs() {
         log.debug("Deleting expired jobs");
-        final Date now = new Date();
-        jobRepository.deleteJobsExpiringBefore(now);
-        log.debug("Deleting old generated files from database");
-        jobRepository.deleteFilesGeneratedBefore(Date.from(now.toInstant().minus(2, ChronoUnit.HOURS)));
+        jobRepository.deleteJobsExpiringBefore(new Date());
     }
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -37,6 +37,8 @@
             <property name="javax.persistence.jdbc.user" value="job_creator" />
             <property name="javax.persistence.jdbc.password" value="password" />
             <property name="eclipselink.logging.level" value="INFO"/>
+            <property name="eclipselink.logging.level.sql" value="FINE"/>
+
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/test/java/uk/co/onsdigital/job/JobControllerTest.java
+++ b/src/test/java/uk/co/onsdigital/job/JobControllerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static uk.co.onsdigital.job.model.StatusDto.PENDING;
 
-public class JobDtoControllerTest {
+public class JobControllerTest {
 
     @Mock
     private DataSetRepository mockDataSetRepository;
@@ -94,7 +94,7 @@ public class JobDtoControllerTest {
     public void shouldCreatePendingInitialFileStatus() throws Exception {
         CreateJobRequest request = request(UUID.randomUUID());
 
-        Map<FileFormat, FileStatusDto> result = JobController.generateFileNames(request);
+        Map<FileFormat, FileStatusDto> result = jobController.getInitialFileStatus(request);
 
         assertThat(result).containsOnlyKeys(FileFormat.CSV);
         assertThat(result.get(FileFormat.CSV).getStatus()).isEqualTo(PENDING);
@@ -183,7 +183,7 @@ public class JobDtoControllerTest {
     public void shouldReturnJobStatusFromCreateRequest() throws Exception {
         CreateJobRequest request = request(UUID.randomUUID());
         when(mockDataSetRepository.findS3urlForDataSet(request.getDataSetId())).thenReturn("s3_url");
-        Mockito.doNothing().when(mockJobRepository).save(any(JobDto.class));
+        when(mockJobRepository.save(any(JobDto.class))).then(ctx -> ctx.getArguments()[0]);
 
         JobDto jobDto = jobController.createJob(request);
 


### PR DESCRIPTION
### What

Changes the job creator to check in the database whether the same file (i.e. same dataset version and filters) has already been requested before requesting it again. This prevents re-submitting the same job multiple times while the file has not yet been generated (completed files would already be detected). This also avoids spamming S3 with checks to see if the file exists if we already know this in the database.

To prevent never resubmitting a job if the original request failed for some transient reason, we record the time the job is submitted to the CSV filterer and will resubmit it if it is over an hour old but not yet complete (logging a warning).

### How to review

`mvn -U clean spring-boot:run` and check that everything works ok.

### Who can review

Anyone but me.